### PR TITLE
smarter updates when syncing finishes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@dnd-kit/utilities": "^3.2.2",
         "@getalby/bitcoin-connect-react": "^3.10.0",
         "@noble/hashes": "^1.6.1",
-        "@nostr/gadgets": "npm:@jsr/nostr__gadgets@^0.0.40",
+        "@nostr/gadgets": "npm:@jsr/nostr__gadgets@^0.0.43",
         "@nostr/tools": "npm:@jsr/nostr__tools@^2.17.2",
         "@radix-ui/react-alert-dialog": "^1.1.4",
         "@radix-ui/react-avatar": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@getalby/bitcoin-connect-react": "^3.10.0",
     "@noble/hashes": "^1.6.1",
-    "@nostr/gadgets": "npm:@jsr/nostr__gadgets@^0.0.42",
+    "@nostr/gadgets": "npm:@jsr/nostr__gadgets@^0.0.43",
     "@nostr/tools": "npm:@jsr/nostr__tools@^2.17.2",
     "@radix-ui/react-alert-dialog": "^1.1.4",
     "@radix-ui/react-avatar": "^1.1.2",

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -145,6 +145,23 @@ export function detectLanguage(text?: string): string | null {
   }
 }
 
+export function batchDebounce<T>(func: (args: T[]) => void, delay: number) {
+  let timeoutId: ReturnType<typeof setTimeout> | null = null
+  let accumulated: T[] = []
+
+  return (arg: T) => {
+    accumulated.push(arg)
+    if (timeoutId) {
+      clearTimeout(timeoutId)
+    }
+    timeoutId = setTimeout(() => {
+      func(accumulated)
+      accumulated = []
+      timeoutId = null
+    }, delay)
+  }
+}
+
 export function parseEmojiPickerUnified(unified: string): string | TEmoji | undefined {
   if (unified.startsWith(':')) {
     const secondColonIndex = unified.indexOf(':', 1)


### PR DESCRIPTION
whenever there is a background syncing going on, when it ends, `onNew()` will be called now. it should have been called before but wasn't, which cause the UI to be stale without the newfound content until the user refreshed manually.

on NoteList and GroupedNoteList `onNew()` was now adapted to perform better when a huge influx of new notes suddenly arrive (we use `batchDebounce` to do a single updates even though `onNew` is called hundreds of times), and the UI is now updated smartly:

- new notes that would be put at the top of the feed are delegated to the `newEvents` array, which gets merged only when the user clicks (these are also sorted now on GroupedNoteList, which is necessary as we assume notes are sorted in the groups calculation).
- older notes, notes authored by the logged account (or, in the case of GroupedNoteList, notes from authors that are at the top but that wouldn't be their top notes so wouldn't change the view) are inserted immediately.