### PR TITLE
support zapping lnurl services with querystrings in their callback URLs

### DIFF
--- a/src/services/lightning.service.ts
+++ b/src/services/lightning.service.ts
@@ -77,8 +77,9 @@ class LightningService {
       comment
     })
     const zapRequest = await client.signer.signEvent(zapRequestDraft)
+    const separator = callback.includes('?') ? '&' : '?'
     const zapRequestRes = await fetch(
-      `${callback}?amount=${amount}&nostr=${encodeURI(JSON.stringify(zapRequest))}&lnurl=${lnurl}`
+      `${callback}${separator}amount=${amount}&nostr=${encodeURI(JSON.stringify(zapRequest))}&lnurl=${lnurl}`
     )
     const zapRequestResBody = await zapRequestRes.json()
     if (zapRequestResBody.error) {


### PR DESCRIPTION
this same mistake has haunted hundreds of developers since lnurl became a thing in 2019.