### PR TITLE
support thumbhash alongside blurhash

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "sonner": "^2.0.5",
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",
+    "thumbhash": "^0.1.1",
     "tippy.js": "^6.3.7",
     "vaul": "^1.1.2",
     "yet-another-react-lightbox": "^3.21.7",

--- a/src/lib/tag.ts
+++ b/src/lib/tag.ts
@@ -1,5 +1,6 @@
-import { TImetaInfo } from '@/types'
+import { base64 } from '@scure/base'
 import { isBlurhashValid } from 'blurhash'
+import { TImetaInfo } from '@/types'
 import * as nip19 from '@nostr/tools/nip19'
 import { isValidPubkey } from './pubkey'
 
@@ -48,26 +49,37 @@ export function generateBech32IdFromATag(tag: string[]) {
 
 export function getImetaInfoFromImetaTag(tag: string[], pubkey?: string): TImetaInfo | null {
   if (tag[0] !== 'imeta') return null
-  const urlItem = tag.find((item) => item.startsWith('url '))
-  const url = urlItem?.slice(4)
-  if (!url) return null
 
-  const imeta: TImetaInfo = { url, pubkey }
-  const blurHashItem = tag.find((item) => item.startsWith('blurhash '))
-  const blurHash = blurHashItem?.slice(9)
-  if (blurHash) {
-    const validRes = isBlurhashValid(blurHash)
-    if (validRes.result) {
-      imeta.blurHash = blurHash
+  const imeta: Partial<TImetaInfo> = { pubkey }
+
+  for (let i = 1; i < tag.length; i++) {
+    const [k, v] = tag[i].split(' ')
+    switch (k) {
+      case 'url':
+        imeta.url = v
+        break
+      case 'thumbhash':
+        try {
+          imeta.thumbHash = base64.decode(v)
+        } catch {
+          /***/
+        }
+        break
+      case 'blurhash':
+        const validRes = isBlurhashValid(v)
+        if (validRes.result) {
+          imeta.blurHash = v
+        }
+        break
+      case 'dim':
+        const [width, height] = v.split('x').map(Number)
+        if (width && height) {
+          imeta.dim = { width, height }
+        }
+        break
     }
   }
-  const dimItem = tag.find((item) => item.startsWith('dim '))
-  const dim = dimItem?.slice(4)
-  if (dim) {
-    const [width, height] = dim.split('x').map(Number)
-    if (width && height) {
-      imeta.dim = { width, height }
-    }
-  }
-  return imeta
+
+  if (!imeta.url) return null
+  return imeta as TImetaInfo
 }

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -114,6 +114,7 @@ export type TLanguage = 'en' | 'zh' | 'pl'
 export type TImetaInfo = {
   url: string
   blurHash?: string
+  thumbHash?: Uint8Array
   dim?: { width: number; height: number }
   pubkey?: string
 }


### PR DESCRIPTION
blurhash: 
<img width="810" height="883" alt="2025-12-08-141717_810x883_scrot" src="https://github.com/user-attachments/assets/356bfe9e-77a1-40ae-b66b-b72e71da7841" />

thumbhash:
<img width="792" height="879" alt="2025-12-08-141731_792x879_scrot" src="https://github.com/user-attachments/assets/5ce31b0b-531e-4e4e-8e54-4060f3089392" />

pictures:
<img width="786" height="916" alt="2025-12-08-142407_786x916_scrot" src="https://github.com/user-attachments/assets/ff08b13a-741f-4ff3-933f-bb5b81af2e21" />

I guess thumbhash is slightly better but it makes no difference, but also doesn't cost much to add.