### PR TITLE
automatically auth to everything

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -22,8 +22,11 @@ initNostrWasm()
   .then((nw) => {
     setNostrWasm(nw)
     setPool(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      new AbstractSimplePool({ verifyEvent, enableReconnect: true, maxWaitForConnection: 3000 }) as any
+      new AbstractSimplePool({
+        verifyEvent,
+        enableReconnect: true,
+        maxWaitForConnection: 3000
+      }) as any
     )
     pool.trackRelays = true
     setReplaceableStore(store)
@@ -40,7 +43,6 @@ initNostrWasm()
     })
 
     document.addEventListener('visibilitychange', () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const relays = (pool as any).relays as Map<string, { connected: boolean }>
       if (document.visibilityState === 'visible' && relays.size > 0) {
         // Wait for WebSocket close events to propagate before checking state.

--- a/src/services/client.service.ts
+++ b/src/services/client.service.ts
@@ -65,6 +65,17 @@ class ClientService extends EventTarget {
     } catch (err) {
       console.warn('no profiles to index?', err)
     }
+
+    pool.automaticallyAuth = (_relay: string) => async (authEvt: EventTemplate) => {
+      if (this.signer) {
+        const evt = await this.signer!.signEvent(authEvt)
+        if (!evt) {
+          throw new Error('sign event failed')
+        }
+        return evt as any
+      }
+      throw new Error("<not logged in, can't automatically auth>")
+    }
   }
 
   async determineTargetRelays(


### PR DESCRIPTION
This is important for https://github.com/nostr-protocol/nips/pull/2156 to work.

It's also not sufficient, as sometimes the requests will be sent before the auth has completed, but for now I think it already helps.

Later we could make these things more configurable so users don't have to perform AUTH everywhere, but that is more complicated.