### PR TITLE
full "editable draft" functionality for pending notes

### DIFF
--- a/src/components/NoteOptions/index.tsx
+++ b/src/components/NoteOptions/index.tsx
@@ -2,6 +2,7 @@ import { useScreenSize } from '@/providers/ScreenSizeProvider'
 import { Ellipsis } from 'lucide-react'
 import { Event } from '@nostr/tools/wasm'
 import { useState } from 'react'
+import PostEditor from '../PostEditor'
 import { DesktopMenu } from './DesktopMenu'
 import { MobileMenu } from './MobileMenu'
 import RawEventDialog from './RawEventDialog'
@@ -16,6 +17,8 @@ export default function NoteOptions({ event, className }: { event: Event; classN
   const [showSubMenu, setShowSubMenu] = useState(false)
   const [activeSubMenu, setActiveSubMenu] = useState<SubMenuAction[]>([])
   const [subMenuTitle, setSubMenuTitle] = useState('')
+  const [isEditorOpen, setIsEditorOpen] = useState(false)
+  const [editingEvent, setEditingEvent] = useState<Event | undefined>()
 
   const closeDrawer = () => {
     setIsDrawerOpen(false)
@@ -32,9 +35,22 @@ export default function NoteOptions({ event, className }: { event: Event; classN
     setShowSubMenu(true)
   }
 
+  const openEditor = () => {
+    setEditingEvent(event)
+    setIsEditorOpen(true)
+  }
+
+  const closeEditor = (open: boolean) => {
+    setIsEditorOpen(open)
+    if (!open) {
+      setEditingEvent(undefined)
+    }
+  }
+
   const menuActions = useMenuActions({
     event,
     closeDrawer,
+    openEditor,
     showSubMenuActions,
     setIsRawEventDialogOpen,
     setIsReportDialogOpen,
@@ -77,6 +93,12 @@ export default function NoteOptions({ event, className }: { event: Event; classN
         event={event}
         isOpen={isReportDialogOpen}
         closeDialog={() => setIsReportDialogOpen(false)}
+      />
+      <PostEditor
+        defaultContent={editingEvent?.content}
+        editingEvent={editingEvent}
+        open={isEditorOpen}
+        setOpen={closeEditor}
       />
     </div>
   )

--- a/src/components/NoteOptions/useMenuActions.tsx
+++ b/src/components/NoteOptions/useMenuActions.tsx
@@ -15,6 +15,7 @@ import {
   CloudUpload,
   Code,
   Copy,
+  FilePen,
   Link,
   Pin,
   PinOff,
@@ -55,6 +56,7 @@ export interface MenuAction {
 interface UseMenuActionsProps {
   event: Event
   closeDrawer: () => void
+  openEditor: () => void
   showSubMenuActions: (subMenu: SubMenuAction[], title: string) => void
   setIsRawEventDialogOpen: (open: boolean) => void
   setIsReportDialogOpen: (open: boolean) => void
@@ -64,6 +66,7 @@ interface UseMenuActionsProps {
 export function useMenuActions({
   event,
   closeDrawer,
+  openEditor,
   showSubMenuActions,
   setIsRawEventDialogOpen,
   setIsReportDialogOpen,
@@ -367,6 +370,19 @@ export function useMenuActions({
     }
 
     if (pubkey && event.pubkey === pubkey) {
+      if (isPending) {
+        actions.push({
+          icon: FilePen,
+          label: t('Edit'),
+          onClick: () => {
+            closeDrawer()
+            openEditor()
+          },
+          className: 'text-black focus:text-black dark:text-black dark:focus:text-black',
+          separator: true
+        })
+      }
+
       actions.push({
         icon: isPending ? CloudUpload : Trash2,
         label: isPending ? t('Publish this note') : t('Try deleting this note'),
@@ -408,6 +424,7 @@ export function useMenuActions({
     pinBuryState,
     feedSettings.grouped,
     closeDrawer,
+    openEditor,
     showSubMenuActions,
     setIsRawEventDialogOpen,
     mutePrivately,

--- a/src/components/PostEditor/PostContent.tsx
+++ b/src/components/PostEditor/PostContent.tsx
@@ -73,12 +73,14 @@ function PendingPublishToast({ endAt, onUndo }: { endAt: number; onUndo: () => v
 
 export default function PostContent({
   defaultContent = '',
+  editingEvent,
   parentEvent,
   close,
   open,
   openFrom
 }: {
   defaultContent?: string
+  editingEvent?: Event
   parentEvent?: Event
   close: () => void
   open: (content?: string) => void
@@ -112,7 +114,7 @@ export default function PostContent({
     relays: []
   })
   const [minPow, setMinPow] = useState(0)
-  const { savePendingEvent } = usePending()
+  const { savePendingEvent, discardPendingEvent } = usePending()
   const isFirstRender = useRef(true)
   const canPost = useMemo(() => {
     return (
@@ -221,6 +223,10 @@ export default function PostContent({
           minPow
         })
 
+        if (editingEvent) {
+          await discardPendingEvent(editingEvent.id)
+        }
+
         client.addEventToCache(newEvent)
         client.emitEphemeralEvent(newEvent)
         postEditorCache.clearPostCache({ defaultContent, parentEvent })
@@ -320,7 +326,11 @@ export default function PostContent({
               })
 
         const signedEvent = await signEvent(draftEvent)
-        savePendingEvent(signedEvent)
+        if (editingEvent) {
+          await discardPendingEvent(editingEvent.id)
+        }
+
+        await savePendingEvent(signedEvent)
         postEditorCache.clearPostCache({ defaultContent, parentEvent })
         deleteDraftEventCache(draftEvent)
         addReplies([signedEvent])
@@ -475,7 +485,7 @@ export default function PostContent({
         <div className="flex gap-2 items-center">
           <div className="flex gap-2 items-center max-sm:hidden">
             <Button variant="secondary" disabled={!canPost || posting} onClick={saveForLater}>
-              {t('Save for later')}
+              {editingEvent ? t('Save') : t('Save for later')}
             </Button>
             <Button
               variant="secondary"
@@ -513,7 +523,7 @@ export default function PostContent({
             disabled={!canPost || posting}
             onClick={saveForLater}
           >
-            {t('Save for later')}
+            {editingEvent ? t('Save') : t('Save for later')}
           </Button>
           <Button
             className="w-full"

--- a/src/components/PostEditor/PostTextarea/index.tsx
+++ b/src/components/PostEditor/PostTextarea/index.tsx
@@ -1,5 +1,5 @@
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
-import { parseEditorJsonToText } from '@/lib/tiptap'
+import { parseEditorJsonToText, parseTextToEditorContent } from '@/lib/tiptap'
 import { cn } from '@/lib/utils'
 import customEmojiService from '@/services/custom-emoji.service'
 import postEditorCache from '@/services/post-editor-cache.service'
@@ -104,7 +104,9 @@ const PostTextarea = forwardRef<
           return parseEditorJsonToText(content.toJSON())
         }
       },
-      content: postEditorCache.getPostContentCache({ defaultContent, parentEvent }),
+      content: parseTextToEditorContent(
+        postEditorCache.getPostContentCache({ defaultContent, parentEvent })
+      ),
       onUpdate(props) {
         setText(parseEditorJsonToText(props.editor.getJSON()))
         postEditorCache.setPostContentCache({ defaultContent, parentEvent }, props.editor.getJSON())

--- a/src/components/PostEditor/index.tsx
+++ b/src/components/PostEditor/index.tsx
@@ -16,18 +16,20 @@ import {
 import { useScreenSize } from '@/providers/ScreenSizeProvider'
 import postEditor from '@/services/post-editor.service'
 import { Event } from '@nostr/tools/wasm'
-import { Dispatch, useMemo, useState } from 'react'
+import { Dispatch, useEffect, useMemo, useState } from 'react'
 import PostContent from './PostContent'
 import Title from './Title'
 
 export default function PostEditor({
   defaultContent = '',
+  editingEvent,
   parentEvent,
   open,
   setOpen,
   openFrom
 }: {
   defaultContent?: string
+  editingEvent?: Event
   parentEvent?: Event
   open: boolean
   setOpen: Dispatch<boolean>
@@ -36,6 +38,11 @@ export default function PostEditor({
   const { isSmallScreen } = useScreenSize()
   const [undoContent, setUndoContent] = useState(defaultContent)
   const [undoKey, setUndoKey] = useState(0)
+
+  useEffect(() => {
+    setUndoContent(defaultContent)
+    setUndoKey((k) => k + 1)
+  }, [defaultContent, editingEvent?.id, parentEvent?.id])
 
   const handleOpen = (content?: string) => {
     if (content !== undefined) {
@@ -48,14 +55,16 @@ export default function PostEditor({
   const content = useMemo(() => {
     return (
       <PostContent
+        key={`${editingEvent?.id ?? parentEvent?.id ?? 'post-editor'}:${undoKey}`}
         defaultContent={undoContent}
+        editingEvent={editingEvent}
         parentEvent={parentEvent}
         close={() => setOpen(false)}
         open={handleOpen}
         openFrom={openFrom}
       />
     )
-  }, [undoKey])
+  }, [editingEvent, openFrom, parentEvent, setOpen, undoKey])
 
   if (isSmallScreen) {
     return (

--- a/src/lib/tiptap.ts
+++ b/src/lib/tiptap.ts
@@ -1,7 +1,10 @@
 import customEmojiService from '@/services/custom-emoji.service'
 import { emojis, shortcodeToEmoji } from '@tiptap/extension-emoji'
-import { JSONContent } from '@tiptap/react'
+import { Content, JSONContent } from '@tiptap/react'
 import * as nip19 from '@nostr/tools/nip19'
+import { formatNpub } from './pubkey'
+
+const PROFILE_MENTION_REGEX = /(^|\s|@)(nostr:)?(npub1[a-z0-9]{58}|nprofile1[a-z0-9]+)/g
 
 export function parseEditorJsonToText(node?: JSONContent) {
   const text = _parseEditorJsonToText(node)
@@ -28,6 +31,45 @@ export function parseEditorJsonToText(node?: JSONContent) {
       }
     })
     .trim()
+}
+
+export function parseTextToEditorContent(content?: Content): Content {
+  if (!content || typeof content !== 'string') return content ?? ''
+
+  const text = content
+
+  const lines = text.split('\n')
+  const docContent: JSONContent[] = []
+  let paragraphContent: JSONContent[] = []
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index]
+
+    if (line === '') {
+      if (paragraphContent.length > 0) {
+        docContent.push({ type: 'paragraph', content: paragraphContent })
+        paragraphContent = []
+      }
+
+      if (index < lines.length - 1) {
+        docContent.push({ type: 'paragraph' })
+      }
+
+      continue
+    }
+
+    if (paragraphContent.length > 0) {
+      paragraphContent.push({ type: 'hardBreak' })
+    }
+
+    paragraphContent.push(...parseTextLineToContent(line))
+  }
+
+  if (paragraphContent.length > 0) {
+    docContent.push({ type: 'paragraph', content: paragraphContent })
+  }
+
+  return { type: 'doc', content: docContent.length > 0 ? docContent : [{ type: 'paragraph' }] }
 }
 
 function _parseEditorJsonToText(node?: JSONContent): string {
@@ -68,4 +110,71 @@ function parseEmojiNodeName(name?: string): string {
   }
   const emoji = shortcodeToEmoji(name, emojis)
   return emoji ? (emoji.emoji ?? '') : ''
+}
+
+function parseTextLineToContent(line: string): JSONContent[] {
+  const content: JSONContent[] = []
+  let lastIndex = 0
+
+  for (const match of line.matchAll(PROFILE_MENTION_REGEX)) {
+    const fullMatch = match[0]
+    const leading = match[1] ?? ''
+    const bech32 = match[3]
+    const start = match.index ?? 0
+    const mentionStart = start + leading.length
+
+    if (start > lastIndex) {
+      content.push({ type: 'text', text: line.slice(lastIndex, start) })
+    }
+
+    if (leading) {
+      content.push({ type: 'text', text: leading })
+    }
+
+    const mention = parseProfileMention(bech32)
+    if (mention) {
+      content.push(mention)
+    } else {
+      content.push({ type: 'text', text: fullMatch.slice(leading.length) })
+    }
+
+    lastIndex = mentionStart + fullMatch.slice(leading.length).length
+  }
+
+  if (lastIndex < line.length) {
+    content.push({ type: 'text', text: line.slice(lastIndex) })
+  }
+
+  return content.length > 0 ? content : [{ type: 'text', text: '' }]
+}
+
+function parseProfileMention(bech32: string): JSONContent | undefined {
+  try {
+    const decoded = nip19.decode(bech32)
+
+    if (decoded.type === 'npub') {
+      return {
+        type: 'mention',
+        attrs: {
+          id: bech32,
+          label: formatNpub(bech32)
+        }
+      }
+    }
+
+    if (decoded.type === 'nprofile') {
+      const npub = nip19.npubEncode(decoded.data.pubkey)
+      return {
+        type: 'mention',
+        attrs: {
+          id: npub,
+          label: formatNpub(npub)
+        }
+      }
+    }
+  } catch {
+    return undefined
+  }
+
+  return undefined
 }


### PR DESCRIPTION
This adds an "Edit" button to pending notes.

<img width="503" height="527" src="https://github.com/user-attachments/assets/4dadc8df-52d4-47a6-b101-333dfd93e12a" />

This allows them to be edited and saved again (when editing a previously-saved note the "Save for later" button becomes only "Save"), or edited and published with the timestamp updated to the current time.

<img width="741" height="461" src="https://github.com/user-attachments/assets/937f52a6-8429-46f8-a5a8-744fc2590d82" />

This PR also fixes the bug that would cause the editor to eat newlines and turn references into their raw form when going back from formed event into the editor (for example when clicking "Undo" the note formatting would be damaged). The AI wrote that "text-to-tiptap-structure" parser code and I don't know if it's good, but in my tests it worked fine. Either way it's already better than before, we can fix later.