### PR TITLE
fix grouped card reply heuristics for target parent author

### DIFF
--- a/src/components/CompactedEventCard/index.tsx
+++ b/src/components/CompactedEventCard/index.tsx
@@ -141,7 +141,11 @@ export default function CompactedEventCard({
 
   useEffect(() => {
     if (!isReply) return
-    setRepliedPubkey(event.tags.find(tagNameEquals('p'))?.[1])
+    setRepliedPubkey(
+      event.tags.findLast(
+        (tag: string[]) => tag[0] === 'p' && !!tag[1] && tag[1] !== event.pubkey
+      )?.[1]
+    )
   }, [event, isReply])
 
   const shouldHide = useMemo(() => {

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -565,6 +565,6 @@ export default {
     Synching: 'Downloading from {{current}}/{{total}} profiles',
     'Protected event (NIP-70)': 'Protected event (NIP-70)',
     Protected: 'Protected',
-    Replying: 'Replying'
+    Replying: 'Replying to'
   }
 }

--- a/src/lib/event.ts
+++ b/src/lib/event.ts
@@ -22,13 +22,14 @@ export function isNsfwEvent(event: Event) {
 }
 
 export function isReplyNoteEvent(event: Event) {
-  if ([ExtendedKind.COMMENT, ExtendedKind.VOICE_COMMENT].includes(event.kind)) {
-    return true
+  if (
+    event.kind === kinds.ShortTextNote ||
+    event.kind === ExtendedKind.COMMENT ||
+    event.kind === ExtendedKind.VOICE_COMMENT
+  ) {
+    const isReply = !!getParentTag(event)
+    return isReply
   }
-  if (event.kind !== kinds.ShortTextNote) return false
-
-  const isReply = !!getParentTag(event)
-  return isReply
 }
 
 export function isFirstLevelReply(event: Event) {


### PR DESCRIPTION
before:
<img width="746" height="661" alt="2026-05-18-112013_746x661_scrot" src="https://github.com/user-attachments/assets/c9016829-e55b-4fc3-ab48-a091b0fa93b3" />
<img width="751" height="687" alt="2026-05-18-112022_751x687_scrot" src="https://github.com/user-attachments/assets/d73b5fe7-4444-4431-bb85-0e6371a6ce9c" />

after:
<img width="757" height="498" alt="2026-05-18-114055_757x498_scrot" src="https://github.com/user-attachments/assets/cd90976d-5ccd-44e5-9312-393cfa0aa09c" />
<img width="762" height="539" alt="2026-05-18-114041_762x539_scrot" src="https://github.com/user-attachments/assets/a74d3375-d1a4-423e-b9e2-df03d9e4d394" />

